### PR TITLE
fix: CORS 헤더 추가로 외부 임베딩 문제 해결

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -284,7 +284,7 @@ export async function OPTIONS() {
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Headers': 'Content-Type, x-chat-history, x-used-suggestions',
     }
   })
 }
@@ -301,7 +301,7 @@ export async function POST(request: NextRequest) {
           headers: {
             'Access-Control-Allow-Origin': '*',
             'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Allow-Headers': 'Content-Type, x-chat-history, x-used-suggestions',
           }
         }
       )
@@ -323,7 +323,7 @@ export async function POST(request: NextRequest) {
           headers: {
             'Access-Control-Allow-Origin': '*',
             'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Allow-Headers': 'Content-Type, x-chat-history, x-used-suggestions',
           }
         }
       )
@@ -377,7 +377,7 @@ export async function POST(request: NextRequest) {
       headers: {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Headers': 'Content-Type, x-chat-history, x-used-suggestions',
       }
     })
 
@@ -393,7 +393,7 @@ export async function POST(request: NextRequest) {
           headers: {
             'Access-Control-Allow-Origin': '*',
             'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Allow-Headers': 'Content-Type, x-chat-history, x-used-suggestions',
           }
         }
       )
@@ -408,7 +408,7 @@ export async function POST(request: NextRequest) {
           headers: {
             'Access-Control-Allow-Origin': '*',
             'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Allow-Headers': 'Content-Type, x-chat-history, x-used-suggestions',
           }
         }
       )
@@ -421,7 +421,7 @@ export async function POST(request: NextRequest) {
         headers: {
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-          'Access-Control-Allow-Headers': 'Content-Type',
+          'Access-Control-Allow-Headers': 'Content-Type, x-chat-history, x-used-suggestions',
         }
       }
     )


### PR DESCRIPTION
- x-used-suggestions 헤더를 Access-Control-Allow-Headers에 추가
- 외부 도메인(mintora.me)에서 API 호출 시 CORS 에러 해결
- 블로그 임베딩 정상 동작을 위한 필수 수정